### PR TITLE
Delay type generation during import to avoid importer assertions

### DIFF
--- a/Assets/CastleDBImporter/Scripts/Editor/CastleDBImporter.cs
+++ b/Assets/CastleDBImporter/Scripts/Editor/CastleDBImporter.cs
@@ -8,6 +8,8 @@ namespace CastleDBImporter
 	[ScriptedImporter(1, "cdb")]
 	public class CastleDBImporter : ScriptedImporter
 	{
+        private CastleDBParser parser = null;
+
 		public override void OnImportAsset(AssetImportContext ctx)
 		{
 			TextAsset castle = new TextAsset(File.ReadAllText(ctx.assetPath));
@@ -15,8 +17,9 @@ namespace CastleDBImporter
 			ctx.AddObjectToAsset("main obj", castle);
 			ctx.SetMainObject(castle);
 
-			CastleDBParser newCastle = new CastleDBParser(castle);
-			CastleDBGenerator.GenerateTypes(newCastle.Root, GetCastleDBConfig());
+            parser = new CastleDBParser(castle);
+
+            EditorApplication.delayCall += new EditorApplication.CallbackFunction(GenerateTypes); // Delay type generation until the asset manager has finished importing
 		}
 
 		public CastleDBConfig GetCastleDBConfig()
@@ -25,5 +28,11 @@ namespace CastleDBImporter
             var path = AssetDatabase.GUIDToAssetPath(guids[0]);
             return AssetDatabase.LoadAssetAtPath(path, typeof(CastleDBConfig)) as CastleDBConfig;
 		}
+
+        private void GenerateTypes()
+        {
+            CastleDBGenerator.GenerateTypes(parser.Root, GetCastleDBConfig());
+            parser = null;
+        }
 	}
 }


### PR DESCRIPTION
I love this little importer, but I was getting assertions on my 2019.1.x Unity build and I wanted to see if I could fix them.

The issue comes with adding extra resources during the import, which seems to confuse the ScriptedImporter and it throws an assertion on AssetDatabase.Refresh(). You can test this simply by running castledb the test project in a 2019.1.x build of Unity!