### PR TITLE
Native color support

### DIFF
--- a/Assets/CastleDBImporter/Sample/CastleDBTest.cs
+++ b/Assets/CastleDBImporter/Sample/CastleDBTest.cs
@@ -19,6 +19,7 @@ public class CastleDBTest : MonoBehaviour
             Debug.Log("[float] damage modifier: " + creature.DamageModifier);
             Debug.Log("[enum] death sound: " + creature.DeathSound);
             Debug.Log("[flag enum] spawn areas: " + creature.SpawnAreas);
+            Debug.Log("[color] color: <color=#" + ColorUtility.ToHtmlStringRGBA(creature.Color) + ">" + creature.Color.ToString() + "</color>"  );
             foreach (var item in creature.DropsList)
             {
                 Debug.Log($"{creature.Name} drops item {item.item} at rate {item.DropChance}");

--- a/Assets/CastleDBImporter/Sample/SampleCDBFile.cdb
+++ b/Assets/CastleDBImporter/Sample/SampleCDBFile.cdb
@@ -34,6 +34,10 @@
 				{
 					"typeStr": "10:Forest,Mountains,Lake,Plains",
 					"name": "SpawnAreas"
+				},
+				{
+					"typeStr": "11",
+					"name": "Color"
 				}
 			],
 			"lines": [
@@ -56,7 +60,8 @@
 					],
 					"DamageModifier": 1,
 					"DeathSound": 0,
-					"SpawnAreas": 4
+					"SpawnAreas": 4,
+					"Color": 7764170
 				},
 				{
 					"id": "Bear",
@@ -66,7 +71,8 @@
 					"Drops": [],
 					"DamageModifier": 2.2,
 					"DeathSound": 1,
-					"SpawnAreas": 9
+					"SpawnAreas": 9,
+					"Color": 9990230
 				},
 				{
 					"id": "Dragon",
@@ -91,7 +97,8 @@
 					],
 					"DamageModifier": 5.6,
 					"DeathSound": 1,
-					"SpawnAreas": 10
+					"SpawnAreas": 10,
+					"Color": 13249323
 				}
 			],
 			"separators": [],

--- a/Assets/CastleDBImporter/Scripts/Editor/CastleDBGenerator.cs
+++ b/Assets/CastleDBImporter/Scripts/Editor/CastleDBGenerator.cs
@@ -93,6 +93,10 @@ namespace CastleDBImporter
                         //look up the line based on the passed in row
                         constructorText += $"{column.Name} = new {config.GeneratedTypesNamespace}.{refType}(root,{config.GeneratedTypesNamespace}.{refType}.GetRowValue(node[\"{column.Name}\"]));\n";
                     }
+                    else if(typeNum == "11")
+                    {
+                        constructorText += $"{column.Name} = CastleDB.GetColorFromString( node[\"{column.Name}\"]);\n";
+                    }
                     else
                     {
                         if(typeNum == "10")
@@ -226,6 +230,16 @@ namespace {config.GeneratedTypesNamespace}
             {cdbconstructorBody}
         }}
         {classTexts}
+
+        // Convert CastleDB color string to Unity Color type.
+        public static Color GetColorFromString( string color)
+        {{
+            int.TryParse(color, out int icolor);
+            float blue = ((icolor >> 0) & 255) / 255.0f;
+            float green = ((icolor >> 8) & 255) / 255.0f;
+            float red = ((icolor >> 16) & 255) / 255.0f;
+            return new Color(red, green, blue);
+        }}
     }}
 }}";
 

--- a/Assets/CastleDBImporter/Scripts/Editor/CastleDBImporter.cs
+++ b/Assets/CastleDBImporter/Scripts/Editor/CastleDBImporter.cs
@@ -8,6 +8,8 @@ namespace CastleDBImporter
 	[ScriptedImporter(1, "cdb")]
 	public class CastleDBImporter : ScriptedImporter
 	{
+        private CastleDBParser parser = null;
+
 		public override void OnImportAsset(AssetImportContext ctx)
 		{
 			TextAsset castle = new TextAsset(File.ReadAllText(ctx.assetPath));
@@ -15,8 +17,9 @@ namespace CastleDBImporter
 			ctx.AddObjectToAsset("main obj", castle);
 			ctx.SetMainObject(castle);
 
-			CastleDBParser newCastle = new CastleDBParser(castle);
-			CastleDBGenerator.GenerateTypes(newCastle.Root, GetCastleDBConfig());
+            parser = new CastleDBParser(castle);
+
+            EditorApplication.delayCall += new EditorApplication.CallbackFunction(GenerateTypes); // Delay type generation until the asset manager has finished importing
 		}
 
 		public CastleDBConfig GetCastleDBConfig()
@@ -25,5 +28,11 @@ namespace CastleDBImporter
             var path = AssetDatabase.GUIDToAssetPath(guids[0]);
             return AssetDatabase.LoadAssetAtPath(path, typeof(CastleDBConfig)) as CastleDBConfig;
 		}
+
+        private void GenerateTypes()
+        {
+            CastleDBGenerator.GenerateTypes(parser.Root, GetCastleDBConfig());
+            parser = null;
+        }
 	}
 }

--- a/Assets/CastleDBImporter/Scripts/Editor/CastleDBUtils.cs
+++ b/Assets/CastleDBImporter/Scripts/Editor/CastleDBUtils.cs
@@ -32,9 +32,7 @@ namespace CastleDBImporter
                 case "8": //nested list type
                     return column.Name;
                 case "11": //color
-                     //TODO: fix color encoding  https://docs.unity3d.com/ScriptReference/ColorUtility.TryParseHtmlString.html
-                    return "string";
-                    // return typeof(Color); 
+                     return "Color"; 
                 default:
                     return "string";
             }

--- a/Assets/TestFolder/GeneratedTypes/CastleDB.cs
+++ b/Assets/TestFolder/GeneratedTypes/CastleDB.cs
@@ -69,5 +69,15 @@ private Modifiers Get(CompiledTypes.Modifiers.RowValues line) { return new Modif
                 }
  } //END OF Modifiers 
 
+
+        // Convert CastleDB color string to Unity Color type.
+        public static Color GetColorFromString( string color)
+        {
+            int.TryParse(color, out int icolor);
+            float blue = ((icolor >> 0) & 255) / 255.0f;
+            float green = ((icolor >> 8) & 255) / 255.0f;
+            float red = ((icolor >> 16) & 255) / 255.0f;
+            return new Color(red, green, blue);
+        }
     }
 }

--- a/Assets/TestFolder/GeneratedTypes/Creatures.cs
+++ b/Assets/TestFolder/GeneratedTypes/Creatures.cs
@@ -16,7 +16,8 @@ public float DamageModifier;
 public List<Drops> DropsList = new List<Drops>();
 public DeathSoundEnum DeathSound;
 public enum DeathSoundEnum {  Sound1 = 0,Sound2 = 1 }public SpawnAreasFlag SpawnAreas;
-[FlagsAttribute] public enum SpawnAreasFlag { Forest = 1,Mountains = 2,Lake = 4,Plains = 8 }
+[FlagsAttribute] public enum SpawnAreasFlag { Forest = 1,Mountains = 2,Lake = 4,Plains = 8 }public Color Color;
+
         public enum RowValues { 
 Squid, 
 Bear, 
@@ -33,6 +34,7 @@ DamageModifier = node["DamageModifier"].AsFloat;
 foreach(var item in node["Drops"]) { DropsList.Add(new Drops(root, item));}
 DeathSound = (DeathSoundEnum)node["DeathSound"].AsInt;
 SpawnAreas = (SpawnAreasFlag)node["SpawnAreas"].AsInt;
+Color = CastleDB.GetColorFromString( node["Color"]);
 
         }  
         


### PR DESCRIPTION
I needed colors for my DamageType text, so I went ahead and implemented this. The ColorUtility parse function expects a hex string. Rather than doing that conversion, I just component-ized the decimal directly to Unity's Color type.

I added a color column to the Creatures sheet which should show up in the test script.

This should be merge-able even though it contains my other pull request.  Let me know if you'd rather me separate them completely!